### PR TITLE
Add multiple capabilities around SMS delivery.

### DIFF
--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -1,0 +1,22 @@
+import requests
+
+class Bitly(object):
+    EP = 'https://api-ssl.bitly.com'
+    def __init__(self, KEY):
+        self.key = KEY
+
+    def shorten(self, url, format='json'):
+        URL = '{}/v3/shorten'.format(self.EP)
+
+        params = {
+            'access_token': self.key,
+            'longUrl': url,
+            'format': format,
+        }
+        tmp = requests.get(URL, params=params)
+
+        try:
+            return tmp.json()['data']['url']
+        except TypeError:
+            return tmp.json()['status_txt']
+

--- a/messaging/sms.py
+++ b/messaging/sms.py
@@ -19,43 +19,64 @@ logging.basicConfig(filename='messaging/twilio_processing.log', format=log_forma
 logging.getLogger('urllib3').setLevel(logging.INFO)
 
 
-def format_phone_numbers(data, ctry):
+def check_format_validity(data, ctry, link):
     if ctry == 'US':
-        return [(pid, '+1{}'.format(nbr)) for pid, nbr in data]
+        return log_length_issues(data, 10, link)
     elif ctry == 'MA':
-        return [(pid, '+212{}'.format(nbr)) for pid, nbr in data]
+        return log_length_issues(data, 9, link)
     elif ctry == 'PH':
-        pass
+        return log_length_issues(data, 10, link)
     else:
         pass
 
 
-def check_format_validity(data, ctry):
-    if ctry == 'US':
-        return log_length_issues(data, 10)
-    elif ctry == 'MA':
-        return log_length_issues(data, 9)
-    elif ctry == 'PH':
-        pass
+def format_phone_numbers(data, ctry, link):
+    if link:
+        if ctry == 'US':
+            return [(pid, '+1{}'.format(nbr), url) for pid, nbr, url in data]
+        elif ctry == 'MA':
+            return [(pid, '+212{}'.format(nbr), url) for pid, nbr, url in data]
+        elif ctry == 'PH':
+            return [(pid, '+63{}'.format(nbr), url) for pid, nbr, url in data]
+        else:
+            sys.exit('STOP! Invalid country. Only US, MA, and PH are valid.')
     else:
-        pass
+        if ctry == 'US':
+            return [(pid, '+1{}'.format(nbr)) for pid, nbr in data]
+        elif ctry == 'MA':
+            return [(pid, '+212{}'.format(nbr)) for pid, nbr in data]
+        elif ctry == 'PH':
+            return [(pid, '+63{}'.format(nbr)) for pid, nbr in data]
+        else:
+            sys.exit('STOP! Invalid country. Only US, MA, and PH are valid.')
 
 
-def log_length_issues(data, digits):
-    valid_nbrs = [(pid, phone) for pid, phone in data if
-                  len(str(phone)) == digits]
+def log_length_issues(data, digits, link):
+    if link:
+        valid_nbrs = [(pid, phone, url) for pid, phone, url in data if
+                      len(str(phone)) == digits]
+    else:
+        valid_nbrs = [(pid, phone) for pid, phone in data if
+                      len(str(phone)) == digits]
     if len(valid_nbrs) != len(data):
         logger.info('Not all numbers valid length; {} numbers being dropped \
                     before sending.'.format(len(data) - len(valid_nbrs)))
     return valid_nbrs
 
 
-def log_numeric_issues(df):
-    clean_nbrs = [
-        (pid, phone) for pid, phone in
-        zip(df.ExternalDataReference, df.SMS_PHONE_CLEAN) if
-        isinstance(phone, int)
-    ]
+def log_numeric_issues(df, link):
+    if link:
+        clean_nbrs = [
+            (pid, phone, url) for pid, phone, url in
+            zip(df.ExternalDataReference, df.SMS_PHONE_CLEAN, df.url) if
+            isinstance(phone, int)
+        ]
+    else:
+        clean_nbrs = [
+            (pid, phone) for pid, phone in
+            zip(df.ExternalDataReference, df.SMS_PHONE_CLEAN) if
+            isinstance(phone, int)
+        ]
     if len(clean_nbrs) != len(df.SMS_PHONE_CLEAN):
         logger.info('Not all numbers numeric; {} numbers being dropped before \
                     sending.'.format(len(df.SMS_PHONE_CLEAN) - len(clean_nbrs)))
@@ -66,9 +87,9 @@ def msg_exists_test(content):
     assert content, 'STOP! Message content is empty.'
 
 
-def phone_checks(df):
-    numeric_numbers = log_numeric_issues(df)
-    valid_numbers = check_format_validity(numeric_numbers, args_dict['nation'])
+def phone_checks(df, nation, link):
+    numeric_numbers = log_numeric_issues(df, link)
+    valid_numbers = check_format_validity(numeric_numbers, nation, link)
     return valid_numbers
 
 
@@ -87,10 +108,11 @@ def run(args_dict):
     d = pd.read_csv(args_dict['phones'], sep=None, engine='python')
 
     # test phone numbers
-    valid_numbers = phone_checks(d)
+    valid_numbers = phone_checks(d, args_dict['nation'], args_dict['url_link'])
 
     # format phone numbers
-    formatted_numbers = format_phone_numbers(valid_numbers, args_dict['nation'])
+    formatted_numbers = format_phone_numbers(valid_numbers, args_dict['nation'],
+                                             args_dict['url_link'])
 
     # authenticate client
     twilio = Client(args_dict['auth'][0], args_dict['auth'][1])
@@ -122,9 +144,43 @@ def run(args_dict):
         length = len(formatted_numbers)
         beg = [x*75 for x in xrange(length/75 + 1)]
         end = [x+75 for x in beg]
-        end[-1] = end[-2] + length % 75
+        end[-1] = end[-2] + length%75
         for b, e in zip(beg, end):
-            for _, phone in formatted_numbers[b:e]:
+            if args_dict['url_link']:
+                for _, phone, url in formatted_numbers[b:e]:
+                    try:
+                        msgs.append(twilio.messages.create(
+                            to=phone,
+                            from_=args_dict['auth'][2],
+                            body='{} {}'.format(msg_content, url),
+                        ))
+                    except:
+                        pass
+            else:
+                for _, phone in formatted_numbers[b:e]:
+                    try:
+                        msgs.append(twilio.messages.create(
+                            to=phone,
+                            from_=args_dict['auth'][2],
+                            body=msg_content,
+                        ))
+                    except:
+                        pass
+            logger.info('Processed {} messages.'.format(len(msgs)))
+            time.sleep(10)
+    else:
+        if args_dict['url_link']:
+            for _, phone, url in formatted_numbers:
+                try:
+                    msgs.append(twilio.messages.create(
+                        to=phone,
+                        from_=args_dict['auth'][2],
+                        body='{} {}'.format(msg_content, url),
+                    ))
+                except:
+                    pass
+        else:
+            for _, phone in formatted_numbers:
                 try:
                     msgs.append(twilio.messages.create(
                         to=phone,
@@ -133,34 +189,27 @@ def run(args_dict):
                     ))
                 except:
                     pass
-            logger.info('Processed {} messages.'.format(len(msgs)))
-            time.sleep(10)
-    else:
-        for _, phone in formatted_numbers:
-            try:
-                msgs.append(twilio.messages.create(
-                    to=phone,
-                    from_=args_dict['auth'][2],
-                    body=msg_content,
-                ))
-            except:
-                pass
         logger.info('Processed {} messages.'.format(len(msgs)))
 
     # sleep for one minute to queue messaging status for return
     time.sleep(45)
 
     # log delivery code
-    delivery = pd.DataFrame(
-        [(pid, msg.fetch().status, msg.sid) for pid, msg in
-         zip([pid for pid, _ in formatted_numbers], msgs)],
-        columns=['ExternalDataReference', 'MessageStatus', 'MessageReference'],
-    )
+    if args_dict['url_link']:
+        delivery = pd.DataFrame(
+            [(pid, msg.fetch().status, msg.sid) for pid, msg in
+             zip([pid for pid, _, __ in formatted_numbers], msgs)],
+            columns=['ExternalDataReference', 'MessageStatus', 'MessageReference'],
+        )
+    else:
+        delivery = pd.DataFrame(
+            [(pid, msg.fetch().status, msg.sid) for pid, msg in
+             zip([pid for pid, _ in formatted_numbers], msgs)],
+            columns=['ExternalDataReference', 'MessageStatus', 'MessageReference'],
+        )
 
     # merge delivery code back to input data
     d = d.merge(delivery, on='ExternalDataReference', how='left')
-
-    #
 
     # output data
     fileparts = os.path.splitext(args_dict['phones'])
@@ -178,8 +227,10 @@ if __name__ == '__main__':
     parser.add_argument('-e', '--error_check', action='store_true',
                         help='Indicate if phone numbers should be checked '
                         'against a known bad/stop list.')
+    parser.add_argument('-l', '--url_link', action='store_true',
+                        help='Indicates if a URL should be sent with the SMS.')
     parser.add_argument('-n', '--nation', required=True,
-                        choices=['MA', 'US'], help='Country 2-letter ISO '
+                        choices=['MA', 'US', 'PH'], help='Country 2-letter ISO '
                         'code for recipients.')
     parser.add_argument('-p', '--phones', required=True, help='Path/file to '
                         'csv with phone delivery information.')

--- a/messaging/tests/sms_tests.py
+++ b/messaging/tests/sms_tests.py
@@ -5,51 +5,55 @@ import pytest
 from NGS2apis.messaging.sms import *
 
 
-@pytest.mark.parametrize('test_data, test_country, expected', [
+@pytest.mark.parametrize('test_data, test_country, test_link, expected', [
     (
         [('A1', 1111111111), ('A2', 2222222222)],
         'US',
+        False,
         [('A1', '+11111111111'), ('A2', '+12222222222')],
     ),
 ])
-def test_format_phone_numbers(test_data, test_country, expected):
-    result = format_phone_numbers(test_data, test_country)
+def test_format_phone_numbers(test_data, test_country, test_link, expected):
+    result = format_phone_numbers(test_data, test_country, test_link)
     assert result[0][0] == expected[0][0]
     assert result[0][1] == expected[0][1]
     assert result[1][0] == expected[1][0]
     assert result[1][1] == expected[1][1]
 
 
-@pytest.mark.parametrize('test_data, test_digits, expected', [
+@pytest.mark.parametrize('test_data, test_digits, test_link, expected', [
     (
         [('A1', 1111111111), ('A2', 222222222), ('A3', 333333333)],
         10,
+        False,
         [('A1', 1111111111)],
     ),
     (
         [('A1', 1111111111), ('A2', 222222222), ('A3', 333333333)],
         9,
+        False,
         [('A2', 222222222), ('A3', 333333333)],
     ),
 ])
-def test_log_length_issues(test_data, test_digits, expected):
-    result = log_length_issues(test_data, test_digits)
+def test_log_length_issues(test_data, test_digits, test_link, expected):
+    result = log_length_issues(test_data, test_digits, test_link)
     assert result[0][0] == expected[0][0]
     assert result[0][1] == expected[0][1]
     assert len(result) == len(expected)
 
 
-@pytest.mark.parametrize('test, expected', [
+@pytest.mark.parametrize('test, test_link, expected', [
     (
         pd.DataFrame({
             'ExternalDataReference': ['A', 'B', 'C'],
             'SMS_PHONE_CLEAN': [8888888888, 'a111111111', 9999999999],
         }),
+        False,
         [('A', 8888888888), ('C', 9999999999)],
     ),
 ])
-def test_log_numeric_issues(test, expected):
-    result = log_numeric_issues(test)
+def test_log_numeric_issues(test, test_link, expected):
+    result = log_numeric_issues(test, test_link)
     assert result[0][0] == expected[0][0]
     assert result[0][1] == expected[0][1]
     assert result[1][0] == expected[1][0]

--- a/messaging/urls.py
+++ b/messaging/urls.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import argparse
+import os
+import pandas as pd
+import time
+
+from NGS2apis.messaging import *
+
+
+def shorten_url(api, ct, link):
+    # avoid rate limits
+    if (ct>0) & (ct%99==0):
+        time.sleep(60)
+
+    # make api call
+    return api.shorten(link)
+
+
+def run(args_dict):
+    # load data
+    d = pd.read_csv(args_dict['data'], sep=None, engine='python')
+
+    # authorize client
+    client = Bitly(args_dict['auth'])
+
+    # iterate over URLs and return bitlinks
+    d['url'] = [shorten_url(client, i, url) for i, url in enumerate(d['link'])]
+
+    # write data to disk
+    FILENAME = os.path.splitext(args_dict['data'])
+    d.to_csv('{}_bitly{}'.format(FILENAME[0], FILENAME[1]), index=False)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run URLs through Bitly for '
+                                     'short URLs.')
+    parser.add_argument('-a', '--auth', required=True, help='Authentication '
+                        'token for Bitly; note, does not use OAuth2.')
+    parser.add_argument('-d', '--data', required=True, help='Path/file for '
+                        'URLs to shorten; must have a field called `link`.')
+    args_dict = vars(parser.parse_args())
+
+    run(args_dict)


### PR DESCRIPTION
This PR addresses a number of areas around the automated delivery
of SMS messages to NGS2 participants. They are:
* Add ability to send messages to the Philippines. Now that the
sample for work includes the Philippines, additional functionality
to process numbers and send messages has been created.
* Gather bitlinks by using the Bitly API. For some messages, we
need to send web links to the empanelment survey (or experiment
instance) and those addresses are generally too long. This PR adds
capabilities to process individualized weblinks through Bitly's
API and return bitlinks that can be inserted into SMS messages.
* Modify how messaged text is processed. With the introduction of
individualized links to add to what has otherwise been static
content to all recipients, there needed to be modifications for
when links are present.